### PR TITLE
v1.3.1 - Updates composer.json to install as wordpress-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This change log adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## Unreleased
 
+## 1.3.1 - 2025-03-31
+- Changes plugin back to installing as standard `wordpress-plugin`, primarily due to the fact that WordPress does not support mu-plugins in subdirectories.
+
 ## 1.3.0 - 2025-03-21
 - [Merges PR #16](https://github.com/Rarst/wps/pull/16) submitted to Rarst/wps to update `composer-installers` version
 - Installs plugin as a `mu-plugin` to better support development on WordPress multi-site

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
 	"name"       : "philipdowner/wp-whoops",
 	"description": "WordPress plugin for whoops error handler.",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"keywords"   : [
 		"wordpress",
 		"wordpress-plugin",
 		"whoops",
 		"error"
 	],
-	"type"       : "wordpress-muplugin",
+	"type"       : "wordpress-plugin",
 	"homepage"   : "https://github.com/Rarst/wps",
 	"license"    : "MIT",
 	"authors"    : [

--- a/wp-whoops.php
+++ b/wp-whoops.php
@@ -4,7 +4,7 @@ Plugin Name: wpWhoops
 Plugin URI: https://github.com/Rarst/wps
 Description: WordPress plugin for Whoops error handler (previously wps).
 Author: Andrey "Rarst" Savchenko
-Version: 1.3.0
+Version: 1.3.1
 Author URI: http://www.rarst.net/
 License: MIT
 


### PR DESCRIPTION
Changes plugin back to installing as standard `wordpress-plugin`, primarily due to the fact that WordPress does not support mu-plugins in subdirectories.